### PR TITLE
Print functions

### DIFF
--- a/examples/programs/D3piTest.cxx
+++ b/examples/programs/D3piTest.cxx
@@ -116,8 +116,8 @@ int main( int argc, char** argv)
 
     LOG(INFO) << D->decayChainAsString();
 
-    std::cout << *M.spinAmplitudeCache() << std::endl;
-    data_accessors_as_string(M, false);
+    LOG(INFO) << *M.spinAmplitudeCache() << std::endl;
+    LOG(INFO) << data_accessors_as_string(M, false);
 
     // get default Dalitz axes
     auto massAxes = M.massAxes();
@@ -135,7 +135,7 @@ int main( int argc, char** argv)
             data.push_back(P);
     }
 
-    masses_as_string(*M.fourMomenta(), data[0]);
+    LOG(INFO) << masses_as_string(*M.fourMomenta(), data[0]);
 
     for (auto p : M.fourMomenta()->finalStateMomenta(data[0]))
         LOG(INFO) << p;

--- a/examples/programs/D3piTest.cxx
+++ b/examples/programs/D3piTest.cxx
@@ -114,8 +114,7 @@ int main( int argc, char** argv)
 
     // std::cout << "\nHelicity angle symmetrizations with " << M.helicityAngles()->maxSymmetrizationIndex() + 1 << " indices \n";
 
-    D->printDecayChain();
-    std::cout << "\n";
+    LOG(INFO) << D->decayChainAsString();
 
     std::cout << *M.spinAmplitudeCache() << std::endl;
     data_accessors_as_string(M, false);
@@ -173,7 +172,7 @@ int main( int argc, char** argv)
                                      [](const std::string & s, const std::complex<double>& c)
     { return s + "\t" + std::to_string(real(c)) + " + " + std::to_string(imag(c));}).erase(0, 1);
 
-    LOG(INFO) << M.initialStateParticle()->printDecayTrees();
+    LOG(INFO) << to_string(M.initialStateParticle()->decayTrees());
 
     LOG(INFO) << "alright!";
 }

--- a/examples/programs/D3piTest.cxx
+++ b/examples/programs/D3piTest.cxx
@@ -118,7 +118,7 @@ int main( int argc, char** argv)
     std::cout << "\n";
 
     std::cout << *M.spinAmplitudeCache() << std::endl;
-    M.printDataAccessors(false);
+    data_accessors_as_string(M, false);
 
     // get default Dalitz axes
     auto massAxes = M.massAxes();
@@ -136,8 +136,7 @@ int main( int argc, char** argv)
             data.push_back(P);
     }
 
-    LOG(INFO) << "AFTER";
-    M.fourMomenta()->printMasses(data[0]);
+    masses_as_string(*M.fourMomenta(), data[0]);
 
     for (auto p : M.fourMomenta()->finalStateMomenta(data[0]))
         LOG(INFO) << p;

--- a/examples/programs/D4piTest.cxx
+++ b/examples/programs/D4piTest.cxx
@@ -115,8 +115,8 @@ int main( int argc, char** argv)
 
     LOG(INFO) << D->decayChainAsString();
 
-    std::cout << *M.spinAmplitudeCache() << std::endl;
-    data_accessors_as_string(M, false);
+    LOG(INFO) << *M.spinAmplitudeCache() << std::endl;
+    LOG(INFO) << data_accessors_as_string(M, false);
 
     LOG(INFO) << "create dataPoints";
 

--- a/examples/programs/D4piTest.cxx
+++ b/examples/programs/D4piTest.cxx
@@ -116,7 +116,7 @@ int main( int argc, char** argv)
     std::cout << "\n";
 
     std::cout << *M.spinAmplitudeCache() << std::endl;
-    M.printDataAccessors(false);
+    data_accessors_as_string(M, false);
 
     LOG(INFO) << "create dataPoints";
 

--- a/examples/programs/D4piTest.cxx
+++ b/examples/programs/D4piTest.cxx
@@ -3,6 +3,7 @@
 #include "DataPoint.h"
 #include "DataSet.h"
 #include "DecayChannel.h"
+#include "DecayTree.h"
 #include "FinalStateParticle.h"
 #include "FourMomenta.h"
 #include "FourVector.h"
@@ -112,8 +113,7 @@ int main( int argc, char** argv)
     for (auto& pc_i : M.helicityAngles()->symmetrizationIndices())
         std::cout << *pc_i.first << ": " << pc_i.second << "\n";
 
-    D->printDecayChain();
-    std::cout << "\n";
+    LOG(INFO) << D->decayChainAsString();
 
     std::cout << *M.spinAmplitudeCache() << std::endl;
     data_accessors_as_string(M, false);
@@ -231,7 +231,7 @@ int main( int argc, char** argv)
     */
 
 
-    LOG(INFO) << D->printDecayTrees();
+    LOG(INFO) << to_string(M.initialStateParticle()->decayTrees());
 
     std::cout << "alright! \n";
 }

--- a/examples/programs/DKKpiTest.cxx
+++ b/examples/programs/DKKpiTest.cxx
@@ -79,7 +79,7 @@ int main( int argc, char** argv)
     auto data = M.createDataSet(1);
 
     DEBUG("BEFORE");
-    M.fourMomenta()->printMasses(data[0]);
+    DEBUG(masses_as_string(*M.fourMomenta(), data[0]));
 
     LOG(INFO) << "setting squared mass ...";
     auto P = M.calculateFourMomenta(massAxes, m2, D);
@@ -91,7 +91,7 @@ int main( int argc, char** argv)
     }
 
     DEBUG("AFTER");
-    M.fourMomenta()->printMasses(data[0]);
+    DEBUG(masses_as_string(*M.fourMomenta(), data[0]));
 
     std::cout << "alright! \n";
 }

--- a/examples/programs/DKKpiTest.cxx
+++ b/examples/programs/DKKpiTest.cxx
@@ -64,8 +64,7 @@ int main( int argc, char** argv)
 
     std::cout << "\nHelicity angle symmetrizations with " << M.helicityAngles()->nSymmetrizationIndices() << " indices \n";
 
-    D->printDecayChain();
-    std::cout << "\n";
+    LOG(INFO) << D->decayChainAsString();
 
     std::cout << *M.spinAmplitudeCache() << std::endl;
     data_accessors_as_string(M, false);

--- a/examples/programs/DKKpiTest.cxx
+++ b/examples/programs/DKKpiTest.cxx
@@ -68,7 +68,7 @@ int main( int argc, char** argv)
     std::cout << "\n";
 
     std::cout << *M.spinAmplitudeCache() << std::endl;
-    M.printDataAccessors(false);
+    data_accessors_as_string(M, false);
 
     // choose default Dalitz coordinates
     const yap::MassAxes massAxes = M.massAxes();

--- a/examples/programs/DKKpiTest.cxx
+++ b/examples/programs/DKKpiTest.cxx
@@ -66,8 +66,8 @@ int main( int argc, char** argv)
 
     LOG(INFO) << D->decayChainAsString();
 
-    std::cout << *M.spinAmplitudeCache() << std::endl;
-    data_accessors_as_string(M, false);
+    LOG(INFO) << *M.spinAmplitudeCache() << std::endl;
+    LOG(INFO) << data_accessors_as_string(M, false);
 
     // choose default Dalitz coordinates
     const yap::MassAxes massAxes = M.massAxes();

--- a/include/CachedDataValue.h
+++ b/include/CachedDataValue.h
@@ -185,8 +185,12 @@ inline bool operator==(const CachedDataValue::Status& S, const VariableStatus& s
 inline bool operator!=(const CachedDataValue::Status& S, const VariableStatus& s)
 { return S.Variable != s; }
 
+/// to_string for CachedDataValue::Status
+std::string to_string(const CachedDataValue::Status& S);
+
 /// streaming operator for CachedDataValue::Status
-std::ostream& operator<<(std::ostream& str, const CachedDataValue::Status& S);
+inline std::ostream& operator<<(std::ostream& str, const CachedDataValue::Status& S)
+{ return str << to_string(S); }
 
 /// \class RealCachedDataValue
 /// \brief Class for managing a single real cached value inside a #DataPoint

--- a/include/CalculationStatus.h
+++ b/include/CalculationStatus.h
@@ -31,17 +31,20 @@ enum class CalculationStatus : bool {
     uncalculated = false
 };
 
-inline std::ostream& operator<<(std::ostream& str, const CalculationStatus& c)
+inline std::string to_string(const CalculationStatus& c)
 {
     switch (c) {
         case CalculationStatus::calculated:
-            return str << "calculated";
+            return "calculated";
         case CalculationStatus::uncalculated:
-            return str << "uncalculated";
+            return "uncalculated";
         default:
-            return str << (int) c;
+            return std::to_string(static_cast<int>(c));
     }
 }
+
+inline std::ostream& operator<<(std::ostream& str, const CalculationStatus& c)
+{ return str << to_string(c); }
 
 }
 

--- a/include/DataAccessor.h
+++ b/include/DataAccessor.h
@@ -65,9 +65,6 @@ public:
     const unsigned nSymmetrizationIndices() const
     { return NIndices_; }
 
-    /// print ParticleCombination map
-    void printParticleCombinations() const;
-
     /// \return CachedDataValueSet
     const CachedDataValueSet& cachedDataValues() const
     { return CachedDataValues_; }

--- a/include/DecayTree.h
+++ b/include/DecayTree.h
@@ -162,6 +162,9 @@ FreeAmplitudeSet freeAmplitudes(const DecayTreeVector& DTV);
 /// \param vector of trees to check in
 const DecayTreeVector select_changed(const DecayTreeVector& dtv);
 
+/// \return map of spin projections to decayTrees as string
+std::string to_string(const std::map<int, DecayTreeVector>& decayTrees);
+
 }
 
 #endif

--- a/include/DecayingParticle.h
+++ b/include/DecayingParticle.h
@@ -131,13 +131,11 @@ public:
     /// @}
 
     /// Print complete decay chain
-    void printDecayChain() const
-    { printDecayChainLevel(0); }
+    std::string decayChainAsString() const
+    { return decayChainLevelAsString(0); }
 
     /// \return raw pointer to Model through first DecayChannel
     const Model* model() const override;
-
-    std::string printDecayTrees() const;
 
     /// grant friend status to DecayChannel to call fixSolitaryFreeAmplitudes()
     /// and storeBlattWeisskopf()
@@ -165,7 +163,7 @@ protected:
     /// if only one decay channel is available, fix its free amplitude to the current value
     void fixSolitaryFreeAmplitudes();
 
-    void printDecayChainLevel(int level) const;
+    std::string decayChainLevelAsString(int level) const;
 
     /// modify a DecayTree
     /// \param dt DecayTree to modify

--- a/include/DecayingParticle.h
+++ b/include/DecayingParticle.h
@@ -130,7 +130,7 @@ public:
 
     /// @}
 
-    /// Print complete decay chain
+    /// \return complete decay chain as (multiline) string
     std::string decayChainAsString() const
     { return decayChainLevelAsString(0); }
 

--- a/include/FourMomenta.h
+++ b/include/FourMomenta.h
@@ -135,7 +135,7 @@ private:
 
 };
 
-/// print all masses
+/// \return all masses as (multiline) string
 std::string masses_as_string(const FourMomenta& fm, const DataPoint& d);
 
 }

--- a/include/FourMomenta.h
+++ b/include/FourMomenta.h
@@ -101,9 +101,6 @@ public:
 
     /// @}
 
-    /// print all masses
-    std::ostream& printMasses(const DataPoint& d, std::ostream& os = std::cout) const;
-
     /// grant friend status to Model to call addParticleCombination and setFinalStateMomenta
     friend class Model;
 
@@ -137,6 +134,9 @@ private:
     std::shared_ptr<RealCachedDataValue> M_;
 
 };
+
+/// print all masses
+std::string masses_as_string(const FourMomenta& fm, const DataPoint& d);
 
 }
 #endif

--- a/include/Model.h
+++ b/include/Model.h
@@ -209,12 +209,6 @@ public:
     /// Set VariableStatus'es of all Parameter's to unchanged, or leave as fixed
     void setParameterFlagsToUnchanged();
 
-    /// Print the list of DataAccessor's
-    void printDataAccessors(bool printParticleCombinations = true) const;
-
-    /// Print all VariableStatus'es and CalculationStatus'es
-    void printFlags(const StatusManager& sm) const;
-
     /// grant friend status to DataAccessor to register itself with this
     friend class DataAccessor;
 
@@ -293,6 +287,12 @@ const double sumOfLogsOfSquaredAmplitudes(const Model& M, DataPartition& D);
 /// \return The sum of the logs of squared amplitudes evaluated over the data partitions
 /// \param DP DataPartitionVector of partitions to use
 const double sumOfLogsOfSquaredAmplitudes(const Model& M, DataPartitionVector& DP);
+
+/// Print the list of DataAccessor's
+std::string data_accessors_as_string(const Model& m, bool printParticleCombinations = true);
+
+/// Print all VariableStatus'es and CalculationStatus'es
+std::string flags_as_string(const Model& m, const StatusManager& sm);
 
 }
 

--- a/include/Model.h
+++ b/include/Model.h
@@ -288,10 +288,12 @@ const double sumOfLogsOfSquaredAmplitudes(const Model& M, DataPartition& D);
 /// \param DP DataPartitionVector of partitions to use
 const double sumOfLogsOfSquaredAmplitudes(const Model& M, DataPartitionVector& DP);
 
-/// Print the list of DataAccessor's
+/// \return the list of DataAccessor's as (multiline) string
+/// \param m Model to print DataAccessor's of
+/// \param printParticleCombinations also print ParticleCombination's of each DataAccessor
 std::string data_accessors_as_string(const Model& m, bool printParticleCombinations = true);
 
-/// Print all VariableStatus'es and CalculationStatus'es
+/// \return all VariableStatus'es and CalculationStatus'es as (multiline) string
 std::string flags_as_string(const Model& m, const StatusManager& sm);
 
 }

--- a/include/ParticleCombination.h
+++ b/include/ParticleCombination.h
@@ -107,7 +107,7 @@ private:
     ParticleCombination() = default;
 
     /// Final-state-particle constructor, see ParticleCombinationCache::fsp for details
-    ParticleCombination(unsigned index) : Indices_(1, index) {}
+    explicit ParticleCombination(unsigned index) : Indices_(1, index) {}
 
     /// Copy constructor is deleted
     ParticleCombination(const ParticleCombination&) = delete;

--- a/include/ParticleCombination.h
+++ b/include/ParticleCombination.h
@@ -236,6 +236,17 @@ std::string to_string(const ParticleCombination& pc);
 /// convert ParticleCombination with top-most parent to string
 std::string to_string_with_parent(const ParticleCombination& pc);
 
+/// convert ParticleCombinationMap to string
+template<typename T>
+inline std::string to_string(const ParticleCombinationMap<T>& pcm)
+{
+    std::string s;
+    using std::to_string;
+    for (auto& kv : pcm)
+        s += to_string(kv.second) + " : " + to_string_with_parent(*(kv.first));
+    return s;
+}
+
 /// streamer
 inline std::ostream& operator<<(std::ostream& os, const ParticleCombination& PC)
 { os << to_string(PC); return os; }

--- a/include/VariableStatus.h
+++ b/include/VariableStatus.h
@@ -30,19 +30,22 @@ enum class VariableStatus : int {
     unchanged = +1,        ///< Parameter is free but has not been changed
 };
 
-inline std::ostream& operator<<(std::ostream& str, const VariableStatus& s)
+inline std::string to_string(const VariableStatus& s)
 {
     switch (s) {
         case VariableStatus::changed:
-            return str << "changed";
+            return "changed";
         case VariableStatus::fixed:
-            return str << "fixed";
+            return "fixed";
         case VariableStatus::unchanged:
-            return str << "unchanged";
+            return "unchanged";
         default:
-            return str << (int) s;
+            return std::to_string(static_cast<int>(s));
     }
 }
+
+inline std::ostream& operator<<(std::ostream& str, const VariableStatus& c)
+{ return str << to_string(c); }
 
 }
 

--- a/src/CachedDataValue.cxx
+++ b/src/CachedDataValue.cxx
@@ -25,9 +25,9 @@ CachedDataValue::Status& CachedDataValue::Status::operator=(const VariableStatus
 }
 
 //-------------------------
-std::ostream& operator<<(std::ostream& str, const CachedDataValue::Status& S)
+std::string to_string(const CachedDataValue::Status& S)
 {
-    return str << S.Calculation << ", " << S.Variable;
+    return to_string(S.Calculation) + ", " + to_string(S.Variable);
 }
 
 //-------------------------

--- a/src/DataAccessor.cxx
+++ b/src/DataAccessor.cxx
@@ -16,13 +16,6 @@ DataAccessor::DataAccessor(const ParticleCombination::Equal& equal) :
 }
 
 //-------------------------
-void DataAccessor::printParticleCombinations() const
-{
-    for (auto& kv : SymmetrizationIndices_)
-        LOG(INFO) << kv.second << " : " << to_string_with_parent(*(kv.first));
-}
-
-//-------------------------
 bool DataAccessor::consistent() const
 {
     bool C = true;

--- a/src/DecayTree.cxx
+++ b/src/DecayTree.cxx
@@ -176,4 +176,15 @@ const DecayTreeVector select_changed(const DecayTreeVector& dtv)
     return C;
 }
 
+//-------------------------
+std::string to_string(const std::map<int, DecayTreeVector>& decayTrees)
+{
+    std::string s;
+    for (const auto& m_dtv : decayTrees) {
+        for (const auto& dt : m_dtv.second)
+            s += "\ndepth = " + std::to_string(depth(*dt)) + "\n" + dt->asString() + "\n";
+    }
+    return s;
+}
+
 }

--- a/src/DecayingParticle.cxx
+++ b/src/DecayingParticle.cxx
@@ -260,8 +260,10 @@ std::vector< std::shared_ptr<FinalStateParticle> > DecayingParticle::finalStateP
 }
 
 //-------------------------
-void DecayingParticle::printDecayChainLevel(int level) const
+std::string DecayingParticle::decayChainLevelAsString(int level) const
 {
+    std::ostringstream os;
+
     // get maximum length of particle names
     static size_t padding = 0;
     static size_t paddingSpinAmp = 0;
@@ -271,33 +273,35 @@ void DecayingParticle::printDecayChainLevel(int level) const
             for (std::shared_ptr<Particle> d : c->daughters()) {
                 padding = std::max(padding, d->name().length());
                 if (std::dynamic_pointer_cast<DecayingParticle>(d))
-                    std::static_pointer_cast<DecayingParticle>(d)->printDecayChainLevel(-1);
+                    os << std::static_pointer_cast<DecayingParticle>(d)->decayChainLevelAsString(-1);
                 paddingSpinAmp = std::max(paddingSpinAmp, to_string(c->spinAmplitudes()).length());
             }
         }
         if (level == -1)
-            return;
+            return os.str();
     }
 
     for (size_t i = 0; i < Channels_.size(); ++i) {
         if (i > 0)
-            std::cout << "\n" << std::setw(level * (padding * 3 + 8 + paddingSpinAmp)) << "";
+            os << "\n" << std::setw(level * (padding * 3 + 8 + paddingSpinAmp)) << "";
 
-        std::cout << std::left << std::setw(padding) << this->name() << " ->";
+        os << std::left << std::setw(padding) << this->name() << " ->";
         for (std::shared_ptr<Particle> d : Channels_[i]->daughters())
-            std::cout << " " << std::setw(padding) << d->name();
-        std::cout << std::left << std::setw(paddingSpinAmp)
+            os << " " << std::setw(padding) << d->name();
+        os << std::left << std::setw(paddingSpinAmp)
                   << to_string(Channels_[i]->spinAmplitudes());
 
         for (std::shared_ptr<Particle> d : Channels_[i]->daughters())
             if (std::dynamic_pointer_cast<DecayingParticle>(d)) {
-                std::cout << ",  ";
-                std::static_pointer_cast<DecayingParticle>(d)->printDecayChainLevel(level + 1);
+                os << ",  ";
+                os << std::static_pointer_cast<DecayingParticle>(d)->decayChainLevelAsString(level + 1);
             }
     }
 
     if (level == 0)
-        std::cout << "\n";
+        os << "\n";
+
+    return os.str();
 }
 
 //-------------------------
@@ -362,17 +366,6 @@ void DecayingParticle::modifyDecayTree(DecayTree& dt) const
         // Add BlattWeisskopf object
         dt.addDataAccessor(*bw->second);
     }
-}
-
-//-------------------------
-std::string DecayingParticle::printDecayTrees() const
-{
-    std::string s;
-    for (const auto& m_dtv : DecayTrees_) {
-        for (const auto& dt : m_dtv.second)
-            s += "\ndepth = " + std::to_string(depth(*dt)) + "\n" + dt->asString() + "\n";
-    }
-    return s;
 }
 
 //-------------------------

--- a/src/FourMomenta.cxx
+++ b/src/FourMomenta.cxx
@@ -157,7 +157,7 @@ std::string masses_as_string(const FourMomenta& fm, const DataPoint& d)
 
     std::set<unsigned> used;
 
-    // print the ISP
+    // the ISP
     for (auto& kv : fm.symmetrizationIndices())
         // if ISP and not yet printed (should only print once)
         if (kv.first->indices().size() == n_fsp and used.find(kv.second) == used.end()) {
@@ -167,7 +167,7 @@ std::string masses_as_string(const FourMomenta& fm, const DataPoint& d)
             used.insert(kv.second);
         }
 
-    // print the FSP's
+    // the FSP's
     for (size_t i = 0; i < fm.model()->finalStateParticles().size(); ++i)
         for (auto& kv : fm.symmetrizationIndices())
             if (kv.first->isFinalStateParticle() and kv.first->indices()[0] == i and used.find(kv.second) == used.end()) {
@@ -178,7 +178,7 @@ std::string masses_as_string(const FourMomenta& fm, const DataPoint& d)
             }
 
 
-    // print the rest in increasing number of particle content
+    // the rest in increasing number of particle content
     for (unsigned i = 2; i < n_fsp; ++i)
         for (auto& kv : fm.symmetrizationIndices())
             // if i-particle mass and not yet printed
@@ -189,7 +189,7 @@ std::string masses_as_string(const FourMomenta& fm, const DataPoint& d)
                 used.insert(kv.second);
             }
 
-    // print unused
+    // unused
     for (auto& kv : fm.symmetrizationIndices())
         if (used.find(kv.second) == used.end()) {
             s += "        : ";

--- a/src/FourMomenta.cxx
+++ b/src/FourMomenta.cxx
@@ -134,8 +134,9 @@ void FourMomenta::calculate(DataPoint& d, StatusManager& sm) const
 }
 
 //-------------------------
-std::ostream& print_mp_string(std::ostream& os, unsigned n, unsigned m_p, std::shared_ptr<ParticleCombination> pc, double m, FourVector<double> p, std::shared_ptr<RealParameter> M = nullptr)
+std::string mp_string(unsigned n, unsigned m_p, std::shared_ptr<ParticleCombination> pc, double m, FourVector<double> p, std::shared_ptr<RealParameter> M = nullptr)
 {
+    std::ostringstream os;
     os << std::setw(n) << indices_string(*pc) << " : "
        << "m = " << std::setprecision(m_p) << m << " GeV/c^2";
     if (M)
@@ -143,61 +144,61 @@ std::ostream& print_mp_string(std::ostream& os, unsigned n, unsigned m_p, std::s
     else
         os << "            " << std::setw(m_p) << " "                << "         ";
     os << "\tp = " << p << " GeV";
-    return os;
+    return os.str();
 }
 
 //-------------------------
-std::ostream& FourMomenta::printMasses(const DataPoint& d, std::ostream& os) const
+std::string masses_as_string(const FourMomenta& fm, const DataPoint& d)
 {
-    os << "Invariant masses:" << std::endl;
-    unsigned n_fsp = model()->finalStateParticles().size();
+    std::string s = "Invariant masses:\n";
+    unsigned n_fsp = fm.model()->finalStateParticles().size();
     unsigned n = n_fsp + 2;
     unsigned m_p = 6;
 
     std::set<unsigned> used;
 
     // print the ISP
-    for (auto& kv : symmetrizationIndices())
+    for (auto& kv : fm.symmetrizationIndices())
         // if ISP and not yet printed (should only print once)
         if (kv.first->indices().size() == n_fsp and used.find(kv.second) == used.end()) {
-            os << "    ISP : ";
-            print_mp_string(os, n, m_p, kv.first, m(d, kv.first), p(d, kv.first));
-            os << std::endl;
+            s += "    ISP : ";
+            s += mp_string(n, m_p, kv.first, fm.m(d, kv.first), fm.p(d, kv.first));
+            s += "\n";
             used.insert(kv.second);
         }
 
     // print the FSP's
-    for (size_t i = 0; i < FSPIndices_.size(); ++i)
-        for (auto& kv : symmetrizationIndices())
+    for (size_t i = 0; i < fm.model()->finalStateParticles().size(); ++i)
+        for (auto& kv : fm.symmetrizationIndices())
             if (kv.first->isFinalStateParticle() and kv.first->indices()[0] == i and used.find(kv.second) == used.end()) {
-                os << "    FSP : ";
-                print_mp_string(os, n, m_p, kv.first, m(d, kv.first), p(d, kv.first), model()->finalStateParticles()[i]->mass());
-                os << std::endl;
+                s += "    FSP : ";
+                s += mp_string(n, m_p, kv.first, fm.m(d, kv.first), fm.p(d, kv.first), fm.model()->finalStateParticles()[i]->mass());
+                s += "\n";
                 used.insert(kv.second);
             }
 
 
     // print the rest in increasing number of particle content
     for (unsigned i = 2; i < n_fsp; ++i)
-        for (auto& kv : symmetrizationIndices())
+        for (auto& kv : fm.symmetrizationIndices())
             // if i-particle mass and not yet printed
             if (kv.first->indices().size() == i and used.find(kv.second) == used.end()) {
-                os << "    " << i << "-p : ";
-                print_mp_string(os, n, m_p, kv.first, m(d, kv.first), p(d, kv.first));
-                os << std::endl;
+                s += "    " + std::to_string(i) + "-p : ";
+                s += mp_string(n, m_p, kv.first, fm.m(d, kv.first), fm.p(d, kv.first));
+                s += "\n";
                 used.insert(kv.second);
             }
 
     // print unused
-    for (auto& kv : symmetrizationIndices())
+    for (auto& kv : fm.symmetrizationIndices())
         if (used.find(kv.second) == used.end()) {
-            os << "        : ";
-            print_mp_string(os, n, m_p, kv.first, m(d, kv.first), p(d, kv.first));
-            os << std::endl;
+            s += "        : ";
+            s += mp_string(n, m_p, kv.first, fm.m(d, kv.first), fm.p(d, kv.first));
+            s += "\n";
             used.insert(kv.second);
         }
 
-    return os;
+    return s;
 }
 
 }

--- a/src/Model.cxx
+++ b/src/Model.cxx
@@ -359,18 +359,15 @@ void Model::prepareDataAccessors()
 
     }
 
-#ifndef ELPP_DISABLE_DEBUG_LOGS
-    std::cout << "StaticDataAccessors:\n";
-    for (auto& D : StaticDataAccessors_) {
-        std::cout << std::endl;
-        D->printParticleCombinations();
-    }
-    std::cout << "DataAccessors:\n";
-    for (auto& D : DataAccessors_) {
-        std::cout << std::endl;
-        D->printParticleCombinations();
-    }
-#endif
+    // print all DataAccessors
+    DEBUG("StaticDataAccessors:");
+    std::for_each(StaticDataAccessors_.begin(), StaticDataAccessors_.end(),
+            [] (const StaticDataAccessor* da) {DEBUG(to_string(da->symmetrizationIndices()))});
+
+    DEBUG("DataAccessors:");
+    DEBUG("StaticDataAccessors:");
+    std::for_each(DataAccessors_.begin(), DataAccessors_.end(),
+            [] (const DataAccessor* da) {DEBUG(to_string(da->symmetrizationIndices()))});
 
     lock();
 }

--- a/src/Model.cxx
+++ b/src/Model.cxx
@@ -638,9 +638,7 @@ void Model::printDataAccessors(bool printParticleCombinations) const
 
         if (printParticleCombinations) {
             std::cout << " \t";
-
-            for (const auto& pc_i : d->symmetrizationIndices())
-                std::cout << *pc_i.first << ":" << pc_i.second << ";  ";
+            to_string(d->symmetrizationIndices());
         }
 
         std::cout << std::endl;

--- a/src/Model.cxx
+++ b/src/Model.cxx
@@ -622,45 +622,58 @@ void Model::setParameterFlagsToUnchanged()
 }
 
 //-------------------------
-void Model::printDataAccessors(bool printParticleCombinations) const
+std::string data_accessors_as_string(const Model& m, bool printParticleCombinations)
 {
+    using std::to_string;
+
     // header
-    std::cout << "DataAccessors of \n"
-              << "index \tnSymIndices \taddress  \tname";
+    std::string s = "DataAccessors of \nindex \tnSymIndices \taddress \tname";
 
     if (printParticleCombinations)
-        std::cout << "\t\tparticleCombinations";
+        s += "\t\tparticleCombinations";
 
-    std::cout << std::endl;
+    s += "\n";
 
-    for (const auto& d : DataAccessors_) {
-        std::cout << d->index() << "  \t" << d->nSymmetrizationIndices() << "  \t\t" << d << "  \t(" << typeid(*d).name() << ")  \t";
+    for (const auto& d : m.dataAccessors()) {
+        std::stringstream ss;
+        ss << d;
+        s +=  to_string(d->index()) + "  \t" + to_string(d->nSymmetrizationIndices()) + "  \t\t"
+                + ss.str() + "  \t(" + typeid(*d).name() + ")  \t";
 
         if (printParticleCombinations) {
-            std::cout << " \t";
-            to_string(d->symmetrizationIndices());
+            s += " \t";
+            s += to_string(d->symmetrizationIndices());
         }
 
-        std::cout << std::endl;
+        s += "\n";
     }
-    std::cout << std::endl;
+    s += "\n";
+
+    return s;
 }
 
 //-------------------------
-void Model::printFlags(const StatusManager& sm) const
+std::string flags_as_string(const Model& m, const StatusManager& sm)
 {
-    for (const auto& d : DataAccessors_) {
-        std::cout << std::endl;
+    using std::to_string;
+    std::string s;
+
+    for (const auto& d : m.dataAccessors()) {
+        s += "\n";
 
         for (auto& c : d->cachedDataValues()) {
-            std::cout << "  CachedDataValue " << c << ": ";
+            std::stringstream ss;
+            ss << c;
+            s += "  CachedDataValue " + ss.str() + ": ";
             for (unsigned i = 0; i < d->nSymmetrizationIndices(); ++i)
-                std::cout << sm.status(*c, i) << "; ";
-            std::cout << "\n";
+                s += to_string(sm.status(*c, i)) + "; ";
+            s += "\n";
         }
     }
 
-    std::cout << std::endl;
+    s += "\n";
+
+    return s;
 }
 
 }

--- a/src/Model.cxx
+++ b/src/Model.cxx
@@ -8,6 +8,7 @@
 #include "DataSet.h"
 #include "DecayChannel.h"
 #include "DecayingParticle.h"
+#include "DecayTree.h"
 #include "FinalStateParticle.h"
 #include "FourMomenta.h"
 #include "HelicityAngles.h"
@@ -72,7 +73,7 @@ const double sum_of_logs_of_squared_amplitudes(const Model& M, DataPartition& D)
         // incoherently sum over initialStateParticles
         for (auto& kv : M.initialStateParticles()) {
             FDEBUG("calculate amplitude for " << to_string(*kv.first) << " with decay trees:");
-            DEBUG(kv.first->printDecayTrees());
+            DEBUG(to_string(kv.first->decayTrees()));
             L += log(kv.second->value() * norm(amplitude(kv.first->decayTrees(), d)));
         }
     }


### PR DESCRIPTION
Convert `void printXxx()` functions to `std::string to_string()` or `xxx_as_string()` functions. 
Make them non-friend non-member functions when possible.

Adapt all exaples and code.