### PR TITLE
fix doxygen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,11 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmakeModules)
 # Add a custom 'doc' target to generate API documentation with Doxygen
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
-	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
-	               ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-	add_custom_target(doc ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
+                   ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+    add_custom_target(doc ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
                       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-					  COMMENT "Generating API documentation with Doxygen" VERBATIM)
+                      COMMENT "Generating API documentation with Doxygen" VERBATIM)
 endif(DOXYGEN_FOUND)
 
 # Default C++ flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,16 @@ project(YAP)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmakeModules)
 
+# Add a custom 'doc' target to generate API documentation with Doxygen
+find_package(Doxygen)
+if(DOXYGEN_FOUND)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
+	               ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+	add_custom_target(doc ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+                      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+					  COMMENT "Generating API documentation with Doxygen" VERBATIM)
+endif(DOXYGEN_FOUND)
+
 # Default C++ flags
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -225,7 +225,7 @@ EXTENSION_MAPPING      =
 # func(std::string) {}). This also make the inheritance and collaboration
 # diagrams that involve STL classes more complete and accurate.
 
-BUILTIN_STL_SUPPORT    = NO
+BUILTIN_STL_SUPPORT    = YES
 
 # If you use Microsoft's C++/CLI language, you should set this option to YES to
 # enable parsing support.
@@ -297,7 +297,7 @@ SYMBOL_CACHE_SIZE      = 0
 # Private class members and static file members will be hidden unless
 # the EXTRACT_PRIVATE and EXTRACT_STATIC tags are set to YES
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES all private members of a class
 # will be included in the documentation.
@@ -568,7 +568,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = include src
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/include @CMAKE_CURRENT_SOURCE_DIR@/src
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is

--- a/include/HelicityAngles.h
+++ b/include/HelicityAngles.h
@@ -46,8 +46,8 @@ namespace yap {
 ///      the \f$ z \f$ axis of its parent frame \f$ \hat{z}_0 \f$,
 ///      define the reference frame:
 ///      - \f$ \hat{z} \equiv \hat{p} \f$
-///      - \f$ \hat{y} \equiv \hat{z}_0 \cross \hat{z} \f$
-///      - \f$ \hat{x} \equiv \hat{y} \cross \hat{z} \f$
+///      - \f$ \hat{y} \equiv \hat{z}_0 \times \hat{z} \f$
+///      - \f$ \hat{x} \equiv \hat{y} \times \hat{z} \f$
 ///   -# Given daughter particle with momentum \f$ \vec{q} \f$
 ///      in the decaying particle's rest frame, the angles are
 ///      - \f$ \cos\theta \equiv \hat{q} \cdot \hat{z} \f$

--- a/include/WignerD.h
+++ b/include/WignerD.h
@@ -35,8 +35,8 @@
 /// We only cache matrix elements with M in [-J, J] and N in [-J, min(0, m)].
 /// This amounts to the lower triangle and the diagonal without the bottom right corner.
 /// The uncached matrix elements are given by the by the symmetries
-///   - \f$ d^{J}_{MN}(\beta) = (-)^(M-N) d^{J}_{NM}(\beta)\f$
-///   - \f$ d^{J}_{MN}(\beta) = (-)^{M-N) d^{J}_{-N-M}(\beta)\f$
+///   - \f$ d^{J}_{MN}(\beta) = (-)^{M-N} d^{J}_{NM}(\beta)\f$
+///   - \f$ d^{J}_{MN}(\beta) = (-)^{M-N} d^{J}_{-N-M}(\beta)\f$
 
 #ifndef yap_WignerD_h
 #define yap_WignerD_h


### PR DESCRIPTION
Fix some LaTeX math errors:
 * Matching brackets;
 * `\cross` -> `\times`.

Introduce a `doc` target to generate documentation in the `${build}/doc` directory.