### PR TITLE
Data point access

### DIFF
--- a/include/FourMomenta.h
+++ b/include/FourMomenta.h
@@ -85,14 +85,6 @@ public:
     /// \param d DataPoint to get data from
     const std::vector<FourVector<double> > finalStateMomenta(const DataPoint& d) const;
 
-    /// \return momentum
-    std::shared_ptr<FourVectorCachedValue> momentum()
-    { return P_; }
-
-    /// \return momentum (const)
-    std::shared_ptr<FourVectorCachedValue> momentum() const
-    { return P_; }
-
     /// @}
 
     /// print all masses

--- a/include/FourMomenta.h
+++ b/include/FourMomenta.h
@@ -85,14 +85,6 @@ public:
     /// \param d DataPoint to get data from
     const std::vector<FourVector<double> > finalStateMomenta(const DataPoint& d) const;
 
-    /// \return masses
-    std::shared_ptr<RealCachedValue> mass()
-    { return M_; }
-
-    /// \return masses (const)
-    std::shared_ptr<RealCachedValue> mass() const
-    { return M_; }
-
     /// \return momentum
     std::shared_ptr<FourVectorCachedValue> momentum()
     { return P_; }

--- a/include/HelicityAngles.h
+++ b/include/HelicityAngles.h
@@ -74,24 +74,8 @@ public:
     /// get azimuthal angle
     double phi(const DataPoint& d, const std::shared_ptr<ParticleCombination>& pc) const;
 
-    /// access azimuthal angle
-    std::shared_ptr<RealCachedValue>& phi()
-    { return Phi_; }
-
-    /// access azimuthal angle (const)
-    const std::shared_ptr<RealCachedValue>& phi() const
-    { return Phi_; }
-
     /// get polar angle
     double theta(const DataPoint& d, const std::shared_ptr<ParticleCombination>& pc) const;
-
-    /// access polar angle
-    std::shared_ptr<RealCachedValue>& theta()
-    { return Theta_; }
-
-    /// access polar angle (const)
-    const std::shared_ptr<RealCachedValue>& theta() const
-    { return Theta_; }
 
     /// grant friend status to Model to call addParticleCombination
     friend class Model;

--- a/include/MeasuredBreakupMomenta.h
+++ b/include/MeasuredBreakupMomenta.h
@@ -62,14 +62,6 @@ public:
     double q(const DataPoint& d, const std::shared_ptr<ParticleCombination>& pc) const
     { return sqrt(q2(d, pc)); }
 
-    /// \return Breakup Momentum
-    std::shared_ptr<RealCachedValue> breakupMomenta()
-    { return Q2_; }
-
-    /// \return Breakup Momentum (const)
-    std::shared_ptr<RealCachedValue> breakupMomenta() const
-    { return Q2_; }
-
     /// grant friend status to Model to call addParticleCombination
     friend class Model;
 


### PR DESCRIPTION
Remove methods that access `RealCachedValue`'s via non const pointers from `DataAccessor`'s like the following:
```cpp
const std::shared_ptr<RealCachedValue>& phi() const
{ return Phi_; }
```