### PR TITLE
Install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,3 +52,13 @@ add_subdirectory(test)
 # Examples are not part of the `all` target.
 # This will provide an `example` target.
 add_subdirectory(examples)
+
+# Install rule for the header directory
+# CMAKE_INSTALL_PREFIX defaults to:
+#  * /usr/local       on UNIX-like systems
+#  * C:\Program Files on Windows
+install(DIRECTORY   ${YAP_SOURCE_DIR}/include/
+        DESTINATION include/YAP
+        FILES_MATCHING PATTERN "*.h"
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,25 +52,9 @@ set(YAP_SOURCES
 
 add_library(YAP SHARED ${YAP_SOURCES})
 
-# install destinations can be passed via the command line:
-# cmake -DLIBRARY_OUTPUT_DIRECTORY:PATH=<lib_path> <path_to_CMakeLists.tex>
-# otherwise, default LD_LIBRARY_PATH
-if(NOT DEFINED LIBRARY_OUTPUT_DIRECTORY)
-	set(LIBRARY_OUTPUT_DIRECTORY ${YAP_SOURCE_DIR}/lib/${CMAKE_BUILD_TYPE})
-endif()
-
-if(NOT DEFINED INCLUDE_OUTPUT_DIRECTORY)
-	set(INCLUDE_OUTPUT_DIRECTORY ${YAP_SOURCE_DIR}/include/YAP)
-endif()
-
-install(TARGETS YAP LIBRARY DESTINATION ${LIBRARY_OUTPUT_DIRECTORY})
-
-# Matches all the headers in ${YAPDID}/include and its subdirs
-file(GLOB_RECURSE
-	 INSTALL_INCLUDES ${YAP_SOURCE_DIR}/include/*.h)
-
-#message(STATUS "${INSTALL_INCLUDES}")
-
-#install(FILE       ${INSTALL_INCLUDES}
-#	    DESTINATION ${INCLUDE_OUTPUT_DIRECTORY}
-#	)
+# Install rule for libYAP.so
+install(TARGETS YAP LIBRARY
+        DESTINATION lib/
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                    GROUP_READ             GROUP_EXECUTE
+                    WORLD_READ             WORLD_EXECUTE)


### PR DESCRIPTION
`make install` installs the header files in `${CMAKE_INSTALL_PREFIX}/include/YAP` with `rw-r--r--` permissions, and the shared library _libYAP.so_ in `${CMAKE_INSTALL_PREFIX}/lib` with `rwxr-xr-x` permissions.

Optionally a `DESTDIR` can be specified at installation-time:
```
$ make DESTDIR=/home/my_user install
```
This will install the files in `${DESTDIR}/${CMAKE_INSTALL_PREFIX}`.

@greenwald Which permissions should the `data/` files have when installed?