### PR TITLE
Swap four momenta

### DIFF
--- a/include/HelicityAngles.h
+++ b/include/HelicityAngles.h
@@ -68,6 +68,9 @@ public:
     /// get helicity angles
     const spherical_angles<double>& operator()(const DataPoint& d, const StatusManager& sm, const std::shared_ptr<const ParticleCombination>& pc) const;
 
+    /// Clear the cache for StatusManager
+    void clearCache(const StatusManager& sm) const;
+
 private:
 
     /// Add cache for StatusManager (thread safe)

--- a/src/HelicityAngles.cxx
+++ b/src/HelicityAngles.cxx
@@ -59,6 +59,16 @@ void HelicityAngles::addToCache(const StatusManager& sm) const
 }
 
 //-------------------------
+void HelicityAngles::clearCache(const StatusManager& sm) const 
+{
+    std::lock_guard<std::mutex> guard(CacheMutex_);
+    if (CachedAngles_.find(&sm) != CachedAngles_.end()) {
+        CachedAngles_.at(&sm).clear();
+        CachedForDataPoint_.at(&sm) = nullptr;
+    }
+}
+
+//-------------------------
 void HelicityAngles::calculateAngles(const DataPoint& d, const StatusManager& sm,
                                      const std::shared_ptr<const ParticleCombination>& pc,
                                      const CoordinateSystem<double, 3>& C, const FourMatrix<double>& boosts) const

--- a/src/Model.cxx
+++ b/src/Model.cxx
@@ -215,6 +215,8 @@ void Model::setFinalStateMomenta(DataPoint& d, const std::vector<FourVector<doub
     // call calculate on all static data accessors in model
     for (const auto& sda : StaticDataAccessors_)
         sda->calculate(d, sm);
+ 
+    HelicityAngles_.clearCache(sm);
 }
 
 //-------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,7 @@ set(YAP_TEST_SOURCES
   test_Spin.cxx
   test_swapDalitzAxes.cxx
   test_swapFinalStates.cxx
+  test_swapFourMomenta.cxx
   test_VariableStatus.cxx
   test_Vector.cxx
   test_WignerD.cxx

--- a/test/helperFunctions.h
+++ b/test/helperFunctions.h
@@ -56,6 +56,7 @@ inline std::shared_ptr<yap::Model> d4pi()
     D->addWeakDecay(rho, rho);
     D->addWeakDecay(a_1, piMinus);
 
+    M->lock();
     return M;
 }
 
@@ -90,6 +91,7 @@ inline std::shared_ptr<yap::Model> dkkp(int pdg_D, std::vector<int> fsps)
     *free_amplitude(*M, yap::from(*D), yap::l_equals(1)) = 1.;
     *free_amplitude(*M, yap::from(*D), yap::l_equals(2)) = 30.;
 
+    M->lock();
     return M;
 }
 
@@ -121,6 +123,7 @@ std::shared_ptr<yap::Model> d3pi()
     // Add channels to D
     D->addWeakDecay(rho, piPlus);
 
+    M->lock();
     return M;
 }
 

--- a/test/test_FourMomenta.cxx
+++ b/test/test_FourMomenta.cxx
@@ -17,9 +17,6 @@ TEST_CASE( "FourMomenta" )
 
     auto M = d3pi<yap::HelicityFormalism>();
 
-    // not locked yet
-    REQUIRE(M->fourMomenta()->consistent() == false);
-    
     auto D = M->createDataSet();
 
     REQUIRE_THROWS_AS( D.createDataPoint(std::vector<yap::FourVector<double> >()), yap::exceptions::EmptyFourMomentaVector );

--- a/test/test_swapFourMomenta.cxx
+++ b/test/test_swapFourMomenta.cxx
@@ -1,0 +1,64 @@
+#include <catch.hpp>
+#include <catch_capprox.hpp>
+
+#include "helperFunctions.h"
+
+#include <BreitWigner.h>
+#include <DataSet.h>
+#include <DecayTree.h>
+#include <FinalStateParticle.h>
+#include <FourVector.h>
+#include <logging.h>
+#include <MassAxes.h>
+#include <MassRange.h>
+#include <Model.h>
+#include <PDL.h>
+
+#include <cmath>
+#include <assert.h>
+
+/**
+ * Test that the amplitude remains the same after swapping the four momenta of the final state particles
+ */
+
+TEST_CASE( "swapFourMomenta" )
+{
+
+    // disable debug logs in test
+    yap::disableLogs(el::Level::Debug);
+    //yap::plainLogs(el::Level::Debug);
+
+    auto m = d4pi();
+    const double D0_mass = yap::read_pdl_file((std::string)::getenv("YAPDIR") + "/data/evt.pdl")["D0"].mass();
+
+    const auto massAxes = m->massAxes();
+    auto m2r = yap::squared(mass_range(D0_mass, m->massAxes(), m->finalStateParticles()));
+    const auto FSPs = m->finalStateParticles();
+    const auto components = m->components();
+    LOG(INFO) << components.size();
+    assert(components.size() == 1);
+
+    std::mt19937 g(164852419);
+
+    for (unsigned i = 0; i < 100; ++i) {
+        std::vector<yap::FourVector<double> > P = yap::phsp(*m, D0_mass, massAxes, m2r, g, std::numeric_limits<unsigned>::max());
+
+        yap::DataSet dataSet(*m);
+
+        dataSet.push_back({P[0], P[1], P[2], P[3]});
+        dataSet.push_back({P[2], P[1], P[0], P[3]}); // 0 <-> 2
+        dataSet.push_back({P[0], P[3], P[2], P[1]}); // 1 <-> 2
+        dataSet.push_back({P[2], P[3], P[0], P[1]}); // both
+
+        m->calculate(dataSet);
+
+        std::vector<std::complex<double> > amplitudes;
+
+        for (auto& dp : dataSet)
+            amplitudes.push_back(yap::amplitude(components[0].decayTrees(), dp));
+
+        for (unsigned i = 1; i < amplitudes.size(); ++i) 
+            REQUIRE(amplitudes[i] == Catch::Detail::CApprox(amplitudes[0]));
+    }
+
+}


### PR DESCRIPTION
Fix a bug: The Helicity angles were erroneously reused for other DataPoints which happened to have the same memory adresses